### PR TITLE
Added order rule for patch of Greetings for No Lore and LGNPC - NoLore

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -3322,3 +3322,11 @@ BOM_Vanilla Trees.ESP
 [Order]
 Unique_CaveRats.ESP
 Synthesis Series - Creatures and Diseases.ESP
+
+[Requires]
+Better Siege at Firemoth Followers.ESP
+Siege at Firemoth.esp
+
+[Order]
+Siege at Firemoth.esp
+Better Siege at Firemoth Followers.ESP

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -461,6 +461,11 @@ Djangos Dialogue.esp
 Less_Generic_Nerevarine.esp
 
 [Order]
+Greetings for No Lore.esp
+LGNPC_NoLore.esp
+GfNL-LGNPC Patch.esp
+
+[Order]
 K_Potion_Upgrade_1.2.esp
 K_Scroll_Upgrade_MW_Trib_Bmoon.esp
 Key Replacer Trib & BM.esp

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -3310,3 +3310,7 @@ BOM_Vanilla_Suran.esp
 [Order]
 BCOM_Suran Expansion.esp
 BCOM_suran underworld_expansion patch.esp
+
+[Order]
+Unique_CaveRats.ESP
+Synthesis Series - Creatures and Diseases.ESP


### PR DESCRIPTION
The comparability patch between [Greetings for No Lore](https://www.nexusmods.com/morrowind/mods/46063) and `LGNPC - NoLore` should come after both plugins.