### PR TITLE
Added tw_mausoleum

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -4354,3 +4354,13 @@ Imperial Factions.ESP
 Imperial Stables.esp
 Beautiful cities of Morrowind.ESP
 Imperial Stables BCOM patch.ESP
+
+
+[Order]
+tw_mausolem.esp
+Beautiful cities of Morrowind.ESP
+
+[Order]
+tw_mausoleum.esp
+Beautiful cities of Morrowind.ESP
+

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -4355,7 +4355,6 @@ Imperial Stables.esp
 Beautiful cities of Morrowind.ESP
 Imperial Stables BCOM patch.ESP
 
-
 [Order]
 tw_mausolem.esp
 Beautiful cities of Morrowind.ESP
@@ -4364,3 +4363,6 @@ Beautiful cities of Morrowind.ESP
 tw_mausoleum.esp
 Beautiful cities of Morrowind.ESP
 
+[Order]
+dh_homes.esp
+Beautiful cities of Morrowind.ESP


### PR DESCRIPTION
https://www.nexusmods.com/morrowind/mods/51260 adds land records (I think it readds vanilla ones?) that bcom has to overwrite to prevent incompatibilities such as seams.
Additionally, I added another rule with the correctly spelled name in case that's fixed.