### PR TITLE
Update mlox_user.txt

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -1296,6 +1296,7 @@ Vvardenfell Brotherhood.esp
 
 [Order]
 The Fires of Orcs.esp
+The_Fires_of_Orc.ESP
 Vvardenfell Brotherhood.esp
 
 [Order]


### PR DESCRIPTION
The previous ESP name appears to be wrong. I removed the 's'. See mod here: https://www.nexusmods.com/morrowind/mods/44982