### PR TITLE
Fixes for TG overhaul, MQ overhaul, Vanilla QT, IL expansion

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -3955,213 +3955,69 @@ Beautiful cities of Morrowind.ESP
 Wares_NPC_TR.esp
 TR_Travels.esp
 
-[Conflict]
- Already merged in Theives Guild Overhaul:
-Thieves' Guild Overhaul.esp
-Thieves' Guild in Gnaar Mok.esp
+[CONFLICT]
+  Already merged in compilation Vanilla Quest Tweaks
+The_Vanilla_Quest_Tweaks_RP_Choices_Consequences_Super_Mega_Package_-_Ultimate_Edition.ESP
+[ANY Morrowind - Immanuel Kant Edition.esp
+     Libertarian Magical Services.esp
+	 The Corpse and the Skooma Pipe Overhaul.esp
+	 Oath to Saint Roris Instead.esp
+	 Redoran Founder's Helm Add-on - Honor the Ancestors.esp
+	 Hentus Needs Pants Overhaul.esp
+	 A Cure for Vampirism - Skink's Solution.esp
+	 Champion of Clutter.esp
+	 Thelas' Pillows Overhaul.esp
+	 Duel of Honor - Improve the Chances.esp
+	 The Frostmoth Smugglers - Properly Rewarded.esp
+	 Strange Man at Gindrala Hleran's House Overhaul.esp
+	 Immersive Neloth Reward.esp
+	 Therana vs. Trerayna.esp
+	 Teach Nels Llendo a Lesson.esp
+	 Hiring Guards for the Redoran Stronghold - Honorable Solution.esp
+	 Pacifist Options - When it Makes Sense.esp
+	 Harvest's End Festival.esp
+	 Fort Moonmoth Fundraiser Dinner.esp
+	 Fargoth in Distress.esp]
 
+[CONFLICT]
+  Already merged in compilation Main Quest Overhaul
+Main_Quest_Overhaul.ESP
+[ANY Vampire_Nerevarine.ESP
+     Sixth House Smugglers.ESP
+	 Past Life Regressions.ESP
+	 Joinable Sixth House - So to Speak.ESP
+	 Exterminate all the Brutes.ESP
+	 Consequences for Looting the Andrano Tomb.ESP
+	 Ashlander Quests.ESP
+	 Hortator.ESP
+	 Imperialist Nerevarine.ESP
+	 Nationalist Nerevarine.ESP
+	 Refuse the Main Quest.ESP
+	 Living With Caius.ESP]
+	 
 [Conflict]
- Already merged in Theives Guild Overhaul:
-Thieves' Guild Overhaul.esp
-Bal Molagmer Add-on.esp
-
+  Already merged in Thieves Guild Overhaul:
+Thieves_Guild_Overhaul.ESP
+[ANY Thieves Guild in Gnaar Mok.esp
+     Bal Molagmer Add-on.esp
+	 Lore-Friendly Bal Molagmer Gloves.esp
+	 More Redoran Master Helms.esp
+	 Plunder the Dungeon.esp
+	 Wanted Posters.esp
+	 Smooth Moves - Romancing Ahnassi.esp]
+	 
 [Conflict]
- Already merged in Theives Guild Overhaul:
-Thieves' Guild Overhaul.esp
-Lore-Friendly Bal Molagmer Gloves.esp
-More Redoran Master Helms.esp
-
-[Conflict]
- Already merged in Theives Guild Overhaul:
-Thieves' Guild Overhaul.esp
-Plunder the Dungeon.esp
-
-[Conflict]
- Already merged in Theives Guild Overhaul:
-Thieves' Guild Overhaul.esp
-Wanted Posters.esp
-Smooth Moves - Romancing Ahnassi.esp
-
-[Conflict]
- Already merged in compilation Main Quest Overhaul:
-Main Quest Overhaul.esp
-Living with Caius.esp
-
-[Conflict]
- Already merged in compilation Main Quest Overhaul:
-Main Quest Overhaul.esp
-Refuse the Main Quest.esp
-
-[Conflict]
- Already merged in compilation Main Quest Overhaul:
-Main Quest Overhaul.esp
-Nationalist Nerevarine.esp
-
-[Conflict]
- Already merged in compilation Main Quest Overhaul:
-Main Quest Overhaul.esp
-Imperialist Nerevarine.esp
-
-[Conflict]
- Already merged in compilation Main Quest Overhaul:
-Main Quest Overhaul.esp
-Hortator.esp
-
-[Conflict]
- Already merged in compilation Main Quest Overhaul:
-Main Quest Overhaul.esp
-Ashlander Quests.esp
-
-[Conflict]
- Already merged in compilation Main Quest Overhaul:
-Main Quest Overhaul.esp
-Consequences for Looting the Andrano Tomb.esp
-
-[Conflict]
- Already merged in compilation Main Quest Overhaul:
-Main Quest Overhaul.esp
-Exterminate all the Brutes.esp
-
-[Conflict]
- Already merged in compilation Main Quest Overhaul:
-Main Quest Overhaul.esp
-Joinable Sixth House - So to Speak.esp
-
-[Conflict]
- Already merged in compilation Main Quest Overhaul:
-Main Quest Overhaul.esp
-Past Life Regressions.esp
-
-[Conflict]
- Already merged in compilation Main Quest Overhaul:
-Main Quest Overhaul.esp
-Sixth House Smugglers.esp
-Vampire Nerevarine.esp
-
-[Conflict]
- Already merged in compilation Imperial Legion Expansion:
+  Already merged in Imperial Legion Expansion:
 Imperial Legion Expansion.esp
-Publius Claudius Follower.esp
-
-[Conflict]
- Already merged in compilation Imperial Legion Expansion:
-Imperial Legion Expansion.esp
-Legionpapers.esp
-
-[Conflict]
- Already merged in compilation Imperial Legion Expansion:
-Imperial Legion Expansion.esp
-dukesarmor.esp
-
-[Conflict]
- Already merged in compilation Imperial Legion Expansion:
-Imperial Legion Expansion.esp
-Imperial Legion Goods.esp
+[ANY Publius_Claudius_Follower.ESP
+     Legionpapers.esp
+	 dukesarmor.esp
+	 Imperial Legion Goods.esp]
 
 [Conflict]
  Choose one:
 The Talos Cult Conspiracy.esp
 Talos Cult Revised.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Morrowind - Immanuel Kant Edition.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Libertarian Magical Services.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-The Corpse and the Skooma Pipe Overhaul.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Oath to Saint Roris Instead.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Redoran Founder's Helm Add-on - Honor the Ancestors.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Hentus Needs Pants Overhaul.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-A Cure for Vampirism - Skink's Solution.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Champion of Clutter.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Thelas' Pillows Overhaul.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Duel of Honor - Improve the Chances.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-The Frostmoth Smugglers - Properly Rewarded.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Strange Man at Gindrala Hleran's House Overhaul.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Immersive Neloth Reward.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Therana vs. Trerayna.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Teach Nels Llendo a Lesson.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Hiring Guards for the Redoran Stronghold - Honorable Solution.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Pacifist Options - When it Makes Sense.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Harvest's End Festival.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Fort Moonmoth Fundraiser Dinner.esp
-
-[Conflict]
- Already merged in compilation VanillaQuest Tweaks:
-The Vanilla Quest_ weaks RP Choices Consequences Super Mega Package - Ultimate Edition.esp
-Fargoth in Distress.esp
 
 [Order]
 rations.esp


### PR DESCRIPTION
Correct spelling Thieves Guild Overhaul, shortens rule
Correct spelling Main Quest Overhaul, shortens rule
Correct spelling Vanilla Quest Tweaks, shortens rule
Shortens Imperial Legion Expansion