### PR TITLE
Added the newer .esp and .esm to Fairytales of Vvardenfell requirements

### DIFF
--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -12078,7 +12078,9 @@ MW_Children_1_0.esm
  ( Ref: "readme Fairytales of Vvardenfell.txt" )
 Fairytales+Lokken1.esp
 [ANY BT_Whitewolf_2_0.esp
-	 BT_Whitewolf_2_0.esm]
+	 BT_Whitewolf_2_0.esm
+	 BT_Whitewolf_2_0_HOTV.esp
+	 BT_Whitewolf_2_0_HOTV.esm]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Falling Down 2.01 [Duncan]


### PR DESCRIPTION
I didn’t touch the TR1_Herbalism.esp line, but I suppose weird little changes can happen with multiple eyes looking at something.

(I suppose just double-check that part to see if it should be there or not. I was just focusing on the Whitewolf part.)