### PR TITLE
Update mlox_user.txt

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -3325,6 +3325,12 @@ Fighters Guild Improved.esp
 		FGI_Vivec_LirielleDebt.esp
 		FGI_Vivec_TongueToad.esp]
 
+[Order]
+Quest Voice Greetings.esp
+Quest Voice Greetings - Class dismissed.ESP
+Fighters Guild Improved.esp
+FGI_QuestVoiceGreetings_Patch.esp
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Fighters Guild Questline Overhaul [zelazko]
 
@@ -8085,8 +8091,3 @@ RP House Hlaalu.esp
 [Order]
 RP House Hlaalu.esp
 Quest Tweaks and Alternatives_<VER>.esp
-
-[Order]
-Quest Voice Greetings.esp
-Quest Voice Greetings - Class dismissed.ESP
-FGI_QuestVoiceGreetings_Patch.esp


### PR DESCRIPTION
Moved my previous edit to Fighters Guild Improved section.

Also realized, that voiced dialogue error that my previous commit was supposed to fix, still occurs if  Fighters Guild Improved.esp is loaded after FGI_QuestVoiceGreetings_Patch.esp

This commit should ensure that voiced dialogues are loaded in correct order.