### PR TITLE
Update mlox_user.txt

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -857,6 +857,10 @@ BCOM_pathgrid_reset.esp
 Interior exterior flag reset.esp
 BCOM_OpenMW_plazas.esp
 
+[Order] ; rule for replacer maintained by ActuallyUlysses here: https://www.nexusmods.com/morrowind/mods/52726
+Beautiful cities of Morrowind.esp
+BalmoraDocks.esp
+
 ;; BCOM Conflicts
 
 [Conflict]
@@ -877,11 +881,16 @@ Balmora Waterworks.esp
 [Conflict]
 	Not compatible with "Beautiful Cities of Morrowind".
 Beautiful cities of Morrowind.esp
-[ANY	BalmoraDocks.esp
-		MDP*.esp
+[ANY	MDP*.esp
 		Duke's Throne Room Overhaul.esp
 		ImperiumCastleEbonheart.esp
 		Accessible Ebonheart Imperial Chapel v<VER>.esp]
+
+[Conflict] ; replacer maintained by ActuallyUlysses
+	Original mod is not compatible with "Beautiful Cities of Morrowind". Use replacer made by ActuallyUlysses
+	[Replacer Download]( https://www.nexusmods.com/morrowind/mods/52726 )
+Beautiful cities of Morrowind.esp
+BalmoraDocks.esp
 
 [Conflict]
 	Already merged into or otherwise replicated by "Beautiful cities of Morrowind".
@@ -4268,11 +4277,6 @@ Memento Mori.esp
 [Order] ; (JosephMcKean) The patch changes the sitter leveled list none chance from 0 to 100
 Memento Mori.esp
 Memento Mori - OpenMW Patch.esp
-
-[Order] ; (ActuallyUlysses) This is a patch for MM + RMR + BCOM. I published in on discord and its currently being tested for left over seams, ters and floaters - Link to discord https://discord.com/channels/210394599246659585/847622100218544158/1097228510579413053
-Memento Mori.esp
-RedMountainReborn.esp
-Memento_Mori_Patch_RMR__BCOM.ESP
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Mines and Caverns [jsp25]


### PR DESCRIPTION
Edits outs changes that were merged by accident (lines **4272 to 4276**)

From line **884 to 894**, provides conflict info and order (lines **860 to 863**) for loading ESPs that are essential for replacers provided here to work: https://www.nexusmods.com/morrowind/mods/52726
If user is not using replacers, mods are incompatible anyway.

**Lines 880 and 881** had to be edited to provide conflict information added above.

Still new to this, so I would appreciate if someone checks that my proposal fits documents design philosophy.