### PR TITLE
Update mlox_user.txt

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -8776,3 +8776,7 @@ Just Twerk (one dancer).esp
 [Order] ; ( Ref: https://www.nexusmods.com/morrowind/mods/48941 ) (MasssiveJuice)
 abotGuars.esp
 abotGuars-OpenMW patch.ESP
+
+[Order] ;
+Rocky_WG_Base_1.1.ESP
+Caldera Priory.ESP


### PR DESCRIPTION
Any mod changing cells West Gash (-3,3) will be incompatible with Caldera Priory.ESP.

This is because Caldera Priory.ESP changes that cell's name to "Caldera Priory" and identifies that cell by name in one of its scripts.

To fix this, Caldera Priory should load after, so that it will overwrite that cell name.