### PR TITLE
BCOM_pathgrid reset, Nordic Fur Armour Replacer, BDI, The Red Bags

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -1022,6 +1022,18 @@ Better Morrowind Armor DeFemm(?).esp
 Remiros' Uniques.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; @Better Dwemer Interiors, @BDI [SilentJacket]
+
+[requires] ; ( ref: https://www.nexusmods.com/morrowind/mods/52916 ) (MasssiveJuice)
+	This plugin requires "Better Dwemer Interiors".
+BDI - Nchuleft.ESP
+BetterDwemerInteriors.esp
+
+[order] ; confirmed with SilentJacket (MasssiveJuice)
+BetterDwemerInteriors.esp
+BDI - Nchuleft.ESP
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Better Siege at Firemoth Followers [PikachunoTM]
 
 [Order]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -4061,8 +4061,12 @@ IO - The Fires of Orc Patch.ESP
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Interesting Outfits - Kinsmer, @IO - Kinsmer [TipsyTekPriest]
 
-[Order]
+[Order] ; ( ref: https://www.nexusmods.com/morrowind/mods/52167 ) (MasssiveJuice)
 Beautiful cities of morrowind.esp
+IO - Kinsmer.ESP
+
+[Order] ; Otherwise BCOM-compatible pathgrid edits will be overwritten (MasssiveJuice)
+BCOM_pathgrid_reset.esp
 IO - Kinsmer.ESP
 
 [Order]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -8815,3 +8815,11 @@ Magical Missions (Amenophis Fix).ESP
 [Order] ; otherwise Nordic Fur Cuirass mesh gets overwritten by vanilla cuirass for males and females (MasssiveJuice)
 Alex's Better Fitted Female Armors.ESP
 Clean_Nordic Fur Armour Replacer Symph.esp
+
+[order] ; ( ref: https://www.nexusmods.com/morrowind/mods/52924 ) (MasssiveJuice)
+TheRedBags.ESP
+TheRedBags_OAAB.ESP
+
+[order] ; ( ref: https://www.nexusmods.com/morrowind/mods/52924 ) (MasssiveJuice)
+TheRedBags.ESP
+TheRedBags_TR.ESP

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -869,6 +869,10 @@ BCOM_Vanilla_Skar.esp
 Beautiful cities of Morrowind.esp
 Bustling Vivec.ESP
 
+[Order] ; otherwise pathgrid changes to moon's new position get overridden by BCOM_Pathgrid_Reset (MasssiveJuice)
+BCOM_pathgrid_reset.esp
+Baar Dau.esp
+
 ;; BCOM Conflicts
 
 [Conflict]
@@ -8795,3 +8799,7 @@ abotGuars-OpenMW patch.ESP
 [Order] ; ( ref: https://www.nexusmods.com/morrowind/mods/43107 ) (MasssiveJuice)
 Magical Missions.ESP
 Magical Missions (Amenophis Fix).ESP
+
+[Order] ; otherwise Nordic Fur Cuirass mesh gets overwritten by vanilla cuirass for males and females (MasssiveJuice)
+Alex's Better Fitted Female Armors.ESP
+Clean_Nordic Fur Armour Replacer Symph.esp


### PR DESCRIPTION
RP's 'Baar Dau' needs to load after BCOM_Pathgrid_Reset, otherwise pathgrid edits from the latter esp remove pathgrid edits from the former. Confirmed this with RandomPal.

IO - Kinsmer needs to load after otherwise its pathgrid edits (compatible with BCOM) get overwritten by BCOM_pathgrid_reset. Source: I made the pathgrid edits for IO - Kinsmer v1.1.1

Nordic Fur Armour Replacer should load after Alex's Better Fitted Female Armors, otherwise the former's Nordic Fur Cuirass gets overwritten by the vanilla style mesh from the latter (for males and females)

Add @bdi rules section and rules for BDI – Nchuleft. Confirmed [order] rule with SilentJacket in the comments section of BDI – Nchuleft's Nexus page.

Add [Order] rules for 'The Red Bags' OAAB and TR addon ESPs. Confirmed this with GrumblingVomit.