### PR TITLE
Expanded JFK+OAAB_Shipwreck rule

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -5544,6 +5544,10 @@ Justice4Khartag+OAAB_Shipwreck - merged.esp
 [ANY	OAAB - Shipwrecks.esp
 		Justice4Khartag.esp]
 
+[Order] ; Original mod's TR patch prob still necessary (Zilophos)
+Justice4Khartag+OAAB_Shipwreck - merged.esp
+OAAB - Shipwrecks - TR Patch.esp
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @OAAB - The Ashen Divide [Remiros]
 


### PR DESCRIPTION
If this mod just fixes conflicts between JFK and OAAB Shipwrecks only, it's assumed that any TR users will still need the patch from OAAB Shipwreck's page and should load it after the merged plugin.