### PR TITLE
Repopulated Morrowind & Distant Fixes Uviriths Manor

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -3294,6 +3294,14 @@ DistantFixesRiseOfHouseTelvanniUL.esp
 HM_DDD_Strongholds_T_v1.0.esp
 DistantFixesUvirithsManor.esp
 
+[Order] ; ( Ref: https://www.nexusmods.com/morrowind/mods/53140 ) confirmed by the mod author on the Nexus page comments (MasssiveJuice)
+Uvirith's Manor.ESP
+HM_DDD_Strongholds_T_v1.0.esp
+
+[Order] ; ( Ref: https://www.nexusmods.com/morrowind/mods/53140 ) confirmed by the mod author on the Nexus page comments (MasssiveJuice)
+Uvirith's Manor.ESP
+DistantFixesUvirithsManor.esp
+
 [Requires] ; (MasssiveJuice)
 DistantFixesUvirithsManor.esp
 [ALL	HM_DDD_Strongholds_T_v1.0.esp

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -6362,7 +6362,8 @@ Morag_Tong_Armor_Revisited.esp
 RepopulatedMorrowind_MoragTongArmorRevisited.esp
 
 ;; Morag Tong Equipment Diversity
-	A patch for "Repopulated Morrowind" and "Morag Tong Equipment Diversity" is provided in the "Repopulated Morrowind" archive.
+[Patch]
+A patch for "Repopulated Morrowind" and "Morag Tong Equipment Diversity" is provided in the "Repopulated Morrowind" archive.
 RepopulatedMorrowind_MoragTongEquipmentDiversity.ESP
 [ALL	RepopulatedMorrowind.ESM
 		Morag Tong Equipment Diversity.ESP]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -6250,178 +6250,206 @@ Religions Elaborated.esp
 
 ; ( Ref: GrumblingVomit reporting them )
 
-[Order]
-RepopulatedMorrowind.esp
-RepopulatedMainland.esp
-
-[Order]
-RepopulatedMorrowind.esp
-RepopulatedBloodmoon.esp
-
-;; Sixth House Obsidian Weapons
-[Patch]
-	A patch for "Repopulated Morrowind" and "Sixth House Obsidian Weapons" is provided in the "Repopulated Morrowind" archive.
-RepopulatedMorrowind_6thHouseObsidWeps.esp
-[ALL	RepopulatedMorrowind.esp
-		Sixth House Obisidian Weapon.esp]
-
-[Order]
-Sixth House Obisidian Weapon.esp
-RepopulatedMorrowind_6thHouseObsidWeps.esp
-
-[Order]
-RepopulatedMorrowind.esp
-RepopulatedMorrowind_6thHouseObsidWeps.esp
-
 ;; An Issue of Thrust
 [Patch]
 	A patch for "Repopulated Morrowind" and "An Issue Of Thrust" is provided in the "Repopulated Morrowind" archive.
 RepopulatedMorrowind_AnIssueOfThrust.esp
-[ALL	RepopulatedMorrowind.esp
+[ALL	RepopulatedMorrowind.ESM
 		An Issue Of Thrust - Main.esp]
-
+		
 [Order]
 An Issue Of Thrust - Main.esp
 RepopulatedMorrowind_AnIssueOfThrust.esp
 
+;; Animated Morrowind
+[Patch] ( ref: mod readme ) No order rule required as patch only edits Repop ESM (MasssiveJuice)
+	A patch for "Repopulated Morrowind" and "Animated Morrowind" is provided in the "Repopulated Morrowind" archive, compatible with either the vanilla or BCOM version of Animated Morrowind
+RepopulatedMorrowind_AnimatedMorrowind.ESP
+[ALL	RepopulatedMorrowind.ESM
+		[ANY	Animated_Morrowind - merged.esp
+					Animated_Morrowind - merged - OpenMW.esp]]
+
+;; Cammona Tong Chitin Armor
+[Patch]
+	A patch for "Repopulated Morrowind" and "Cammona Tong Chitin" is provided in the "Repopulated Morrowind" archive.
+RepopulatedMorrowind_CamonnaTongChitin.ESP
+[ALL	RepopulatedMorrowind.ESM
+		Cammona Tong Chitin Armor.ESP]
+		
 [Order]
-RepopulatedMorrowind.esp
-RepopulatedMorrowind_AnIssueOfThrust.esp
+Cammona Tong Chitin Armor.ESP
+RepopulatedMorrowind_CamonnaTongChitin.ESP
 
 ;; Ceremonial Adamantium Armor
 [Patch]
 	A patch for "Repopulated Morrowind" and "Ceremonial Adamantium Armor" is provided in the "Repopulated Morrowind" archive.
 RepopulatedMorrowind_CeremonialAdamantiumArmor.esp
-[ALL	RepopulatedMorrowind.esp
+[ALL	RepopulatedMorrowind.ESM
 		Ceremonial Adamantium Armor.esp]
-
+		
 [Order]
 Ceremonial Adamantium Armor.esp
 RepopulatedMorrowind_CeremonialAdamantiumArmor.esp
 
+;; Concept Art Dunmer Helmets
+[Patch]
+	A patch for "Repopulated Morrowind" and "Concept Art Dunmer Helmets" is provided in the "Repopulated Morrowind" archive.
+RepopulatedMorrowind_ConceptArtDunmerHelmets.ESP
+[ALL	RepopulatedMorrowind.ESM
+		Concept Art Dunmer Helms.ESP]
+		
 [Order]
-RepopulatedMorrowind.esp
-RepopulatedMorrowind_CeremonialAdamantiumArmor.esp
+Concept Art Dunmer Helms.ESP
+RepopulatedMorrowind_ConceptArtDunmerHelmets.ESP
 
 ;; Glass Helm Compilation
 [Patch]
 	A patch for "Repopulated Morrowind" and "Glass Helm Compilation" is provided in the "Repopulated Morrowind" archive.
 RepopulatedMorrowind_GlassHelmCompilation.esp
-[ALL	RepopulatedMorrowind.esp
+[ALL	RepopulatedMorrowind.ESM
 		Glass Helms.esp]
-
+		
 [Order]
 Glass Helms.esp
-RepopulatedMorrowind_GlassHelmCompilation.esp
+RepopulatedMorrowind_GlassHelmCompilation.esp	
 
-[Order]
-RepopulatedMorrowind.esp
-RepopulatedMorrowind_GlassHelmCompilation.esp
+;; Immersive Mournhold
+[Patch] ; patch deletes two NPC spawns from Repop ESM for compatibility with Immersive Mournhold and does not have load order requirements (MasssiveJuice)
+	A patch for "Repopulated Morrowind" and "Immersive Mournhold" is provided in the "Repopulated Morrowind" archive.
+RepopulatedMorrowind_ImmersiveMournhold.ESP
+[ALL	RepopulatedMorrowind.ESM
+		Immersive Mournhold.esp]
 
 ;; Indoril Ronin (Armor plugin specifically)
 [Patch]
 	A patch for "Repopulated Morrowind" and "Indoril Ronin" (Armor plugin specifically) is provided in the "Repopulated Morrowind" archive.
 RepopulatedMorrowind_IndorilRoninArmor.esp
-[ALL	RepopulatedMorrowind.esp
+[ALL	RepopulatedMorrowind.ESM
 		Indoril Ronin Armor.esp]
-
+		
 [Order]
 Indoril Ronin Armor.esp
-RepopulatedMorrowind_IndorilRoninArmor.esp
-
-[Order]
-RepopulatedMorrowind.esp
 RepopulatedMorrowind_IndorilRoninArmor.esp
 
 ;; Mage Robes
 [Patch]
 	A patch for "Repopulated Morrowind" and "Mage Robes" is provided in the "Repopulated Morrowind" archive.
 RepopulatedMorrowind_MageRobes.esp
-[ALL	RepopulatedMorrowind.esp
+[ALL	RepopulatedMorrowind.ESM
 		Mage Robes.esp]
 
 [Order]
 Mage Robes.esp
 RepopulatedMorrowind_MageRobes.esp
 
-[Order]
-RepopulatedMorrowind.esp
-RepopulatedMorrowind_MageRobes.esp
-
 ;; Morag Tong Armor Revisited
 [Patch]
 	A patch for "Repopulated Morrowind" and "Morag Tong Armor Revisited" is provided in the "Repopulated Morrowind" archive.
 RepopulatedMorrowind_MoragTongArmorRevisited.esp
-[ALL	RepopulatedMorrowind.esp
+[ALL	RepopulatedMorrowind.ESM
 		Morag_Tong_Armor_Revisited.esp]
 
 [Order]
 Morag_Tong_Armor_Revisited.esp
 RepopulatedMorrowind_MoragTongArmorRevisited.esp
 
+;; Morag Tong Equipment Diversity
+	A patch for "Repopulated Morrowind" and "Morag Tong Equipment Diversity" is provided in the "Repopulated Morrowind" archive.
+RepopulatedMorrowind_MoragTongEquipmentDiversity.ESP
+[ALL	RepopulatedMorrowind.ESM
+		Morag Tong Equipment Diversity.ESP]
+
 [Order]
-RepopulatedMorrowind.esp
-RepopulatedMorrowind_MoragTongArmorRevisited.esp
+Morag Tong Equipment Diversity.ESP
+RepopulatedMorrowind_MoragTongEquipmentDiversity.ESP
 
 ;; Morag Tong Polished
 [Patch]
 	A patch for "Repopulated Morrowind" and "Morag Tong Polished" is provided in the "Repopulated Morrowind" archive.
 RepopulatedMorrowind_MoragTongPolished.esp
-[ALL	RepopulatedMorrowind.esp
+[ALL	RepopulatedMorrowind.ESM
 		Morag Tong Polished.esp]
 
 [Order]
 Morag Tong Polished.esp
 RepopulatedMorrowind_MoragTongPolished.esp
 
-[Order]
-RepopulatedMorrowind.esp
-RepopulatedMorrowind_MoragTongPolished.esp
-
-;; Weapons Expansion Project
-[Patch]
-	A patch for "Repopulated Morrowind" and "Weapons Expansion Project" is provided in the "Repopulated Morrowind" archive.
-RepopulatedMorrowind_MorrowindWeaponsExpansion.esp
-[ALL	RepopulatedMorrowind.esp
-		Weapons Expansion Morrowind.esp]
-
-[Order]
-Weapons Expansion Morrowind.esp
-RepopulatedMorrowind_MorrowindWeaponsExpansion.esp
-
-[Order]
-RepopulatedMorrowind.esp
-RepopulatedMorrowind_MorrowindWeaponsExpansion.esp
-
 ;; Netch adamantium armour integrated
 [Patch]
 	A patch for "Repopulated Morrowind" and "Netch adamantium armour integrated" is provided in the "Repopulated Morrowind" archive.
 RepopulatedMorrowind_NetchAdamantiumArmor.esp
-[ALL	RepopulatedMorrowind.esp
+[ALL	RepopulatedMorrowind.ESM
 		Netch Adamantium Armor II_RP.esp]
 
 [Order]
 Netch Adamantium Armor II_RP.esp
 RepopulatedMorrowind_NetchAdamantiumArmor.esp
 
-[Order]
-RepopulatedMorrowind.esp
-RepopulatedMorrowind_NetchAdamantiumArmor.esp
-
-;; Redoran War Armor and Sathil Mercenary Equipment
+;; Province Cyrodiil
 [Patch]
-	A patch for "Repopulated Morrowind" and "Redoran War Armor and Sathil Mercenary Equipment" is provided in the "Repopulated Morrowind" archive.
-RepopulatedMorrowind_RedoranWarSathilMerc.esp
-[ALL	RepopulatedMorrowind.esp
-		Redoran War and Sathil Mercenary Armor.esp]
+	A patch for "Repopulated Morrowind" and "Province Cyrodiil" is provided in the "Repopulated Morrowind" archive.
+RepopulatedStirk.ESP
+[ALL	RepopulatedMorrowind.ESM
+		Cyr_Main.esm
+	
+;; Redaynia Restored
+[Patch]
+	A patch for "Repopulated Morrowind" and "Redaynia Restored" is provided in the "Repopulated Morrowind" archive.
+RepopulatedMorrowind_RedayniaRestored.ESP
+[ALL	RepopulatedMorrowind.ESM
+		Redaynia Restored.ESP]
 
 [Order]
-Redoran War and Sathil Mercenary Armor.esp
-RepopulatedMorrowind_RedoranWarSathilMerc.esp
+Redaynia Restored.ESP
+RepopulatedMorrowind_RedayniaRestored.ESP
+
+;; Sacred Necromancer Armor
+[Patch]
+	A patch for "Repopulated Morrowind" and "Sacred Necromancer Armor" is provided in the "Repopulated Morrowind" archive.
+RepopulatedMorrowind_SacredNecromancerArmor.ESP
+[ALL	RepopulatedMorrowind.ESM
+		Sacred_Necromancer.esp]
 
 [Order]
-RepopulatedMorrowind.esp
-RepopulatedMorrowind_RedoranWarSathilMerc.esp
+Sacred_Necromancer.esp
+RepopulatedMorrowind_SacredNecromancerArmor.ESP
+
+;; Sixth House Obsidian Weapons
+[Patch] ; ( Ref: mod author GrumblingVomit ) (MasssiveJuice)
+	A patch for "Repopulated Morrowind" and "Sixth House Obsidian Weapons" is provided in the "Repopulated Morrowind" archive. The patch also works if only using "Vanilla Friendly Creatures and Undeads Expansion"
+RepopulatedMorrowind_6thHouseObsidWeps.esp
+[ALL	RepopulatedMorrowind.ESM
+		[ANY    Sixth House Obisidian Weapon.esp
+					Creatures_RP_Purist.esp]]
+					
+[Order]
+Sixth House Obisidian Weapon.esp
+RepopulatedMorrowind_6thHouseObsidWeps.esp
+
+;; Vanilla Friendly Wearables Expansion
+[Patch]
+	A patch for "Repopulated Morrowind" and "Vanilla Friendly Wearables Expansion" is provided in the "Repopulated Morrowind" archive.
+RepopulatedMorrowind_VanillaFriendlyWearablesExpansion.ESP
+[ALL	RepopulatedMorrowind.ESM
+		Vanilla friendly wearables expansion.esm]
+
+[Conflict] ; ( ref: mod readme ) (MasssiveJuice)
+	Already merged into the "Repopulated Morrowind" patch for "Vanilla Friendly Wearables Expansion".
+RepopulatedMorrowind_VanillaFriendlyWearablesExpansion.ESP
+[ANY	RepopulatedMorrowind_CeremonialAdamantiumArmor.ESP
+		RepopulatedMorrowind_ConceptArtDunmerHelmets.ESP
+		RepopulatedMorrowind_RedoranWarSathilMerc.ESP]
+
+;; Weapons Expansion Project
+[Patch]
+	A patch for "Repopulated Morrowind" and "Weapons Expansion Project" is provided in the "Repopulated Morrowind" archive.
+RepopulatedMorrowind_MorrowindWeaponsExpansion.esp
+[ALL	RepopulatedMorrowind.ESM
+		Weapons Expansion Morrowind.esp]
+
+[Order]
+Weapons Expansion Morrowind.esp
+RepopulatedMorrowind_MorrowindWeaponsExpansion.esp
 
 ;; General Conflicts
 [Conflict]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -6363,7 +6363,7 @@ RepopulatedMorrowind_MoragTongArmorRevisited.esp
 
 ;; Morag Tong Equipment Diversity
 [Patch]
-A patch for "Repopulated Morrowind" and "Morag Tong Equipment Diversity" is provided in the "Repopulated Morrowind" archive.
+	A patch for "Repopulated Morrowind" and "Morag Tong Equipment Diversity" is provided in the "Repopulated Morrowind" archive.
 RepopulatedMorrowind_MoragTongEquipmentDiversity.ESP
 [ALL	RepopulatedMorrowind.ESM
 		Morag Tong Equipment Diversity.ESP]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -6270,7 +6270,7 @@ An Issue Of Thrust - Main.esp
 RepopulatedMorrowind_AnIssueOfThrust.esp
 
 ;; Animated Morrowind
-[Patch] ( ref: mod readme ) No order rule required as patch only edits Repop ESM (MasssiveJuice)
+[Patch] ; ( ref: mod readme ) No order rule required as patch only edits Repop ESM (MasssiveJuice)
 	A patch for "Repopulated Morrowind" and "Animated Morrowind" is provided in the "Repopulated Morrowind" archive, compatible with either the vanilla or BCOM version of Animated Morrowind
 RepopulatedMorrowind_AnimatedMorrowind.ESP
 [ALL	RepopulatedMorrowind.ESM

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -6393,12 +6393,6 @@ RepopulatedMorrowind_NetchAdamantiumArmor.esp
 [Order]
 Netch Adamantium Armor II_RP.esp
 RepopulatedMorrowind_NetchAdamantiumArmor.esp
-
-;; Province Cyrodiil
-[Requires]
-RepopulatedStirk.ESP
-[ALL	RepopulatedMorrowind.ESM
-		Cyr_Main.esm]
 	
 ;; Redaynia Restored
 [Patch]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -6395,8 +6395,7 @@ Netch Adamantium Armor II_RP.esp
 RepopulatedMorrowind_NetchAdamantiumArmor.esp
 
 ;; Province Cyrodiil
-[Patch]
-	A patch for "Repopulated Morrowind" and "Province Cyrodiil" is provided in the "Repopulated Morrowind" archive.
+[Requires]
 RepopulatedStirk.ESP
 [ALL	RepopulatedMorrowind.ESM
 		Cyr_Main.esm]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -6399,7 +6399,7 @@ RepopulatedMorrowind_NetchAdamantiumArmor.esp
 	A patch for "Repopulated Morrowind" and "Province Cyrodiil" is provided in the "Repopulated Morrowind" archive.
 RepopulatedStirk.ESP
 [ALL	RepopulatedMorrowind.ESM
-		Cyr_Main.esm
+		Cyr_Main.esm]
 	
 ;; Redaynia Restored
 [Patch]


### PR DESCRIPTION
Overhaul of Repopulated Morrowind rules now that Repop uses its own ESM,
Adjustment to Distant Fixes Uviriths Manor rules