### PR TITLE
DSO Vaermina, Mages Guilde Ovrhl Update mlox_user.txt

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -4719,10 +4719,9 @@ Vivec - God the City.esp
 		Mages Guild Experience Overhaul Max.esp]
 
 ;; Redesigned Vivec Version
-[Requires] ; plugin has DR_data set as master ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
+[Requires] ; ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
 Mages Guild Experience Overhaul RedVivec.esp
-[ALL	DR_Data.esm
-		Compatible Redesigned Vivec.esp]
+Compatible Redesigned Vivec.esp
 
 [Conflict] ; ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
 	Use 'Mages Guild Experience Overhaul RedVivec.esp', which is compatible with "Compatible Redesigned Vivec".

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -3234,6 +3234,38 @@ Dagon fell additions.esp
 Dagon fell additions- ROHT.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; @Daedric Shrine Overhauls [Glittergear]
+
+[Order] ; ( Ref: https://www.nexusmods.com/morrowind/mods/51882 ) (yohannes)
+The Doors of Oblivion 1.4.esp
+Daedric Shrine Overhaul Malacath.esp
+
+[Order] ; ( Ref: https://www.nexusmods.com/morrowind/mods/51607 ) (yohannes)
+The Doors of Oblivion 1.4.esp
+Daedric Shrine Overhaul Mehrunes Dagon.esp
+
+[Order] ; ( Ref: https://www.nexusmods.com/morrowind/mods/51632 ) (yohannes)
+The Doors of Oblivion 1.4.esp
+Daedric Shrine Overhaul Molag Bal.esp
+
+[Order] ; ( Ref: https://www.nexusmods.com/morrowind/mods/51890 ) (yohannes)
+The Doors of Oblivion 1.4.esp
+Daedric Shrine Overhaul Sheogorath.esp
+
+[Order] ; ( ref: https://www.nexusmods.com/morrowind/mods/53242 ) (yohannes)
+The Doors of Oblivion 1.4.esp
+Daedric Shrine Overhaul Vaermina.esp
+
+[Order] ; ( ref: https://www.nexusmods.com/morrowind/mods/53242 ) (yohannes)
+The Doors of Oblivion 1.4.esp
+Daedric Shrine Overhaul Vaermina v2.esp
+
+[Conflict] ; ( ref: https://www.nexusmods.com/morrowind/mods/53242 ) (yohannes)
+	Use only one of these plugins.
+Daedric Shrine Overhaul Vaermina.esp
+Daedric Shrine Overhaul Vaermina v2.esp
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @The Demon Of Knowledge, @Demon Of Knowledge [Corsair, Danae, Darknut, Merlord]
 
 [Order]
@@ -3389,23 +3421,6 @@ Doors of Oblivion+TOTSP Patch.esp
 [Order]
 The Doors of Oblivion*.esp
 Corprusarium_Doors_of_Oblivion_Patch.esp
-
-;;Daedric Shrine Overhauls
-[Order] ; ( Ref: https://www.nexusmods.com/morrowind/mods/51882 ) (yohannes)
-The Doors of Oblivion 1.4.esp
-Daedric Shrine Overhaul Malacath.esp
-
-[Order] ; ( Ref: https://www.nexusmods.com/morrowind/mods/51607 ) (yohannes)
-The Doors of Oblivion 1.4.esp
-Daedric Shrine Overhaul Mehrunes Dagon.esp
-
-[Order] ; ( Ref: https://www.nexusmods.com/morrowind/mods/51632 ) (yohannes)
-The Doors of Oblivion 1.4.esp
-Daedric Shrine Overhaul Molag Bal.esp
-
-[Order] ; ( Ref: https://www.nexusmods.com/morrowind/mods/51890 ) (yohannes)
-The Doors of Oblivion 1.4.esp
-Daedric Shrine Overhaul Sheogorath.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Dwemer Contraband [Hive Master]
@@ -4656,6 +4671,76 @@ Mage Robes_Weak.esp
 Mage Robes.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; @Mages Guild Overhaul and Stronghold [Glittergear]
+
+;; General
+[Conflict] ; ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
+	Use only one of these plugins:
+		'Mages Guild Experience Overhaul Full.esp' - Full Version. Not compatible with any mod that modifies the Balmora/Ald'Ruhn/Vivec Mages Guild.
+		'Mages Guild Experience Overhaul GtC.esp' - Version that is compatible with "God the City".
+		'Mages Guild Experience Overhaul RedVivec.esp' - Version that is compatible with "Redesigned Vivec".
+		'Mages Guild Experience Overhaul Max.esp' - Should be compatible with any mod that modifies the (Mages) Guild Halls including "BCOM".
+Mages Guild Experience Overhaul Full.esp
+Mages Guild Experience Overhaul GtC.esp
+Mages Guild Experience Overhaul RedVivec.esp
+Mages Guild Experience Overhaul Max.esp
+
+[Conflict] ; Mages Guild Overhaul changes the same vanilla quests ( ref: included .docx ) (yohannes)
+	Incompatible with "Mages Guild Overhauls and Stronghold".
+Mages Guild Experience Overhaul*.esp
+[ANY	Different Types of Local Plants for Ajira's Reports.esp
+		sei-MG_potion.esp
+		sei-mg_stealbook.esp
+		onsr.esp
+		onsr-bcom.esp]
+
+;; Full Version
+[Conflict] ; ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
+	The mod archive of "Mages Guild Overhaul and Stronghold" provides several versions compatible with popular city mods. Choose the right version for your setup.
+Mages Guild Experience Overhaul Full.esp
+[ANY	Vivec - God the City.esp
+		Redesigned Vivec.esp
+		Compatible Redesigned Vivec.esp
+		Beautiful cities of Morrowind.esp
+		Morrowind Rebirth [Main].ESP
+		Vivec_Mages_Guild_Expanded.ESP]
+		
+;; God the City Version
+[Requires] ; ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
+	This Plugin requires "Vivec - God the City".
+Mages Guild Experience Overhaul GtC.esp
+Vivec - God the City.esp
+
+[Conflict] ; ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
+	Use 'Mages Guild Experience Overhaul GtC.esp', which is compatible with "Vivec - God of the City".
+Vivec - God the City.esp
+[ANY	Mages Guild Experience Overhaul Full.esp
+		Mages Guild Experience Overhaul RedVivec.esp
+		Mages Guild Experience Overhaul Max.esp]
+
+;; Redesigned Vivec Version
+[Requires] ; plugin has DR_data set as master ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
+Mages Guild Experience Overhaul RedVivec.esp
+[ALL	DR_Data.esm
+		Compatible Redesigned Vivec.esp]]
+
+[Conflict] ; ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
+	Use 'Mages Guild Experience Overhaul RedVivec.esp', which is compatible with "Compatible Redesigned Vivec".
+Compatible Redesigned Vivec.esp
+[ANY	Mages Guild Experience Overhaul Full.esp
+		Mages Guild Experience Overhaul GtC.esp
+		Mages Guild Experience Overhaul Max.esp]
+
+;; Max Compatibility Version
+[Conflict] ; ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
+	Incompatible. Choose the Maximum Compatibility Version that is provided in the "Magic Guild Overhaul and Stronghold" archive.
+[ANY	Mages Guild Experience Overhaul RedVivec.esp
+		Mages Guild Experience Overhaul GtC.esp]
+[ANY	Beautiful cities of Morrowind.esp
+		Morrowind Rebirth [Main].esp
+		Vivec_Mages_Guild_Expanded.esp]
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Magical Missions [Von Djangos]
 
 [Order] ; ( ref: https://www.nexusmods.com/morrowind/mods/43107 ) (MasssiveJuice)
@@ -5785,6 +5870,13 @@ Of Justice and Innocence.esp
 OJAI - Framerate Version.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; @Of Murk and Mussels - A Sadrith Mora Shop [DetailDevil]
+
+[Order] ; ( ref: https://www.nexusmods.com/morrowind/mods/53238 ) (yohannes)
+Sadrith Mora - seat of power.esm
+Of_Murk_and_Mussels_Sadrith_Mora_Seat_of_Power_patch.esp
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Oh No Stolen Reports [johnnyhostile]
 
 [Order] ; dependent on BCOM esp (MasssiveJuice)
@@ -5795,9 +5887,6 @@ onsr-bcom.esp
 	Use only one of these plugins.
 onsr.esp
 onsr-bcom.esp
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; @Old Mournhold Expansion [millerMill]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Ownership Overhaul [Necrolesian]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -4722,7 +4722,7 @@ Vivec - God the City.esp
 [Requires] ; plugin has DR_data set as master ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
 Mages Guild Experience Overhaul RedVivec.esp
 [ALL	DR_Data.esm
-		Compatible Redesigned Vivec.esp]]
+		Compatible Redesigned Vivec.esp]
 
 [Conflict] ; ( ref: https://www.nexusmods.com/morrowind/mods/51897 ) (yohannes)
 	Use 'Mages Guild Experience Overhaul RedVivec.esp', which is compatible with "Compatible Redesigned Vivec".


### PR DESCRIPTION
- moved old DSO rules to new seperate section, added rules for newly released Vaermina Shrine Overhaul
- added section and rules for Mages Guild Overhaul, might need updating once more load order issues/conflicts are known or major updates/patches are released
- added rules for Of Murk and Mussels - A Sadrith Mora Shop
- removed Old Mournhold Expansion section marker since the section is empty