### PR TITLE
Justice for Khartag and OAAB Shipwrecks patch update

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -5825,9 +5825,16 @@ Moonmoth Legion Fort Overhaul.esp
 OAAB - Shipwrecks.esp
 OAAB - Shipwrecks - TR Patch.esp
 
-[Order] ; Otherwise two ships in the same place (Pharis)
-Justice4Khartag.esp
+[Order] ; Updated load order per Justice for Khartag update 03-Oct-23 (MasssiveJuice)
 OAAB - Shipwrecks.esp
+Justice4Khartag.esp
+KFG_Shipwrecks_Patch.ESP
+
+[Patch] ; OAAB Shipwrecks and Justice for Khartag patch (MasssiveJuice)
+	"Justice for Khartag" includes a compatibility patch for "OAAB Shipwrecks" as a separate plugin
+KFG_Shipwrecks_Patch.ESP
+[ALL	OAAB - Shipwrecks.esp
+		Justice4Khartag.esp]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @OAAB Shipwrecks and Justice for Khartag - merged plugin [Corsair, Vegetto, ffann1998]


### PR DESCRIPTION
03-Oct-2023 update to JFK changes its compatibility patch from being an ESP replacer for OAAB Shipwrecks to being a separate ESP