### PR TITLE
MassiveJuice's Pull Request 2: Mlox Base Text Boogaloo

### DIFF
--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -162,6 +162,7 @@ No-Frills Open Vivec*.esp
 Magicka of the Third Era.esp
 fogpatch.esp
 Piratelords Trade Enhancements.esp
+For_the_Right_Price.ESP ; ( Ref: https://www.nexusmods.com/morrowind/mods/52668 )
 NOM <VER>.esp
 GUARD-Remover.esp ; ( Ref: "Advanced GUARDS IV.doc" )
 MW Containers Animated exp.esp ; ( Ref: "aceg_readme.txt" )

--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -162,7 +162,6 @@ No-Frills Open Vivec*.esp
 Magicka of the Third Era.esp
 fogpatch.esp
 Piratelords Trade Enhancements.esp
-For_the_Right_Price.ESP ; ( Ref: https://www.nexusmods.com/morrowind/mods/52668 )
 NOM <VER>.esp
 GUARD-Remover.esp ; ( Ref: "Advanced GUARDS IV.doc" )
 MW Containers Animated exp.esp ; ( Ref: "aceg_readme.txt" )

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -3094,6 +3094,13 @@ CCM-SecretsofVos-V2-TB.esp
 CCM-SecretsofVos-V2-TB - Script Fix.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; @Census and Excise Office Faction [AliceL93]
+Census_and_Excise_Office_Faction.ESP
+[Order] ; From Alvazir's Various Patches (MasssiveJuice)
+
+Census_and_Excise_Office_Faction - Tamriel_Data Patch.esp
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Concept Art Ordinators, @Indoril Spear [RandomPal]
 
 [Order]
@@ -5896,6 +5903,10 @@ OAAB Brother Junipers Twin Lamps.esp
 OAAB Brother Junipers Twin Lamps.esp
 OAAB Brother Junipers Twin Lamps - Script Fix.esp
 
+[Order] ; From Alvazir's Various Patches (MasssiveJuice)
+OAAB Brother Junipers Twin Lamps.esp
+OAAB Brother Junipers Twin Lamps - Tamriel_Data Patch.esp
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @OAAB Grazelands [Melchior Dahrk]
 
@@ -8151,6 +8162,10 @@ VFWE_merged_objects_fix.esp
 [Order]
 VFWE_merged_objects_fix.ESP
 VFWE_The_Raven.ESP
+
+[Order] ; overwrites NPC record (MasssiveJuice)
+The_Fires_of_Orc.ESP
+VFWE - The Fires of Orc Patch.ESP
 
 [Conflict]
 	Already merged into or otherwise replicated by "Vanilla Friendly Wearables Expansion".

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -3095,9 +3095,9 @@ CCM-SecretsofVos-V2-TB - Script Fix.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Census and Excise Office Faction [AliceL93]
-Census_and_Excise_Office_Faction.ESP
-[Order] ; From Alvazir's Various Patches (MasssiveJuice)
 
+[Order] ; From Alvazir's Various Patches (MasssiveJuice)
+Census_and_Excise_Office_Faction.ESP
 Census_and_Excise_Office_Faction - Tamriel_Data Patch.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
[Order] rule added for VFWE 'The Fires of Orc Patch'
[Order] rule and rules section added for 'Census and Excise Office Faction' by AliceL93
[Order] rule added for 'OAAB Brother Junipers Twin Lamps'

Omitted [NearEnd] rule previously added to `mlox_base.txt` for the mod 'For the Right Price' as it was not fully substantiated as being necessary.