### PR TITLE
OAAB Grazelands/Quest Tweaks and Alternatives [Order] rule

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -6024,6 +6024,11 @@ Valley of the Wind Overhaul.esp
 OAAB_GoldenReeds.esp
 OAAB_Grazelands.esp
 
+
+[Order] ; 'OAAB Grazelands' must load after to prevent conflict in 'Girith's Stolen Hides' quest (ref: MelchiorDahrk) (MassiveJuice)
+Quest Tweaks and Alternatives_<VER>.esp
+OAAB_Grazelands.esp
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @OAAB Greater Samarys [Varlothen]
 


### PR DESCRIPTION
`[Order]` rule added to load 'OAAB Grazelands' after any version of StuporStar's 'Quest Tweaks and Alternatives' to prevent a conflict with 'Girith's Stolen Hides' quest.