### PR TITLE
Various order rules

### DIFF
--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -4699,7 +4699,7 @@ Dangerous Roads of Morrowind*.esp
 ;; @Kogoruhn - Extinct City of Ash and Sulfur, @Kogoruhn ECoAaS [johnnyhostile]
 
 ;; 'Riharradroon - Hidden Path to Kogoruhn'
-;; Previously a required mod. Noww compatible, but not required (see comments on Kogoruhn mod page by Demanufacturer87 on 2023-04-11 and 2023-11-06)
+;; Previously a required mod. Now compatible, but not required (see comments on Kogoruhn mod page by Demanufacturer87 on 2023-04-11 and 2023-11-06)
 [Order] ; ( ref: previously advised in mod description before dependency removed in v2.4, https://www.nexusmods.com/morrowind/mods/51615 ) (MasssiveJuice)
 Riharradroon - Path to Kogoruhn v1.0.ESP
 Kogoruhn - Extinct City of Ash and Sulfur.esp

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -4696,6 +4696,15 @@ KogoruhnExpanded.esp
 Dangerous Roads of Morrowind*.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; @Kogoruhn - Extinct City of Ash and Sulfur, @Kogoruhn ECoAaS [johnnyhostile]
+
+;; 'Riharradroon - Hidden Path to Kogoruhn'
+;; Previously a required mod. Noww compatible, but not required (see comments on Kogoruhn mod page by Demanufacturer87 on 2023-04-11 and 2023-11-06)
+[Order] ; ( ref: previously advised in mod description before dependency removed in v2.4, https://www.nexusmods.com/morrowind/mods/51615 ) (MasssiveJuice)
+Riharradroon - Path to Kogoruhn v1.0.ESP
+Kogoruhn - Extinct City of Ash and Sulfur.esp
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @LDM [Lucevar]
 
 [Order]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -4696,17 +4696,6 @@ KogoruhnExpanded.esp
 Dangerous Roads of Morrowind*.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; @Kogoruhn - Extinct City of Ash and Sulfur, @Kogoruhn ECoAaS [johnnyhostile]
-
-[Order] ; ( ref: https://www.nexusmods.com/morrowind/mods/51615 ) (MasssiveJuice)
-Riharradroon - Path to Kogoruhn v1.0.ESP
-Kogoruhn - Extinct City of Ash and Sulfur.esp
-
-[Requires]
-Kogoruhn - Extinct City of Ash and Sulfur.esp
-Riharradroon - Path to Kogoruhn v1.0.ESP
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @LDM [Lucevar]
 
 [Order]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -7241,7 +7241,7 @@ The Sable Dragon*.esp
 Shipyards of Vvardenfell.esp
 Beautiful Cities of Morrowind.esp
 
-[Order] ; See mod description ( Ref: https://www.nexusmods.com/morrowind/mods/51928) (Dary)
+[Order] ; See mod description ( Ref: https://www.nexusmods.com/morrowind/mods/51928 ) (Dary)
 Marbled Zafirbel Bay.esp
 Shipyards of Vvardenfell.esp
 

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -475,6 +475,12 @@ Meteorite Ministry Palace*.esp
 Meteorite Ministry Temple*.esp
 Higher Ministry of Truth.esp
 
+[Note] ; ( Ref: https://www.nexusmods.com/morrowind/mods/51813 )
+	Make sure to use the patch from Vegetto's Important Patches
+	[Patch Download]( https://www.nexusmods.com/morrowind/mods/51813 )
+[ALL	Meteorite Ministry Palace.esp
+	Baar Dau - Ministry of Truth.esp]
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Balmora Gravemarket [Markond]
 

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -467,16 +467,25 @@ RPNR_Shrine_Of_Azura_Aspect_Of_Azura_Patch.esp
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Baar Dau Mods, @Meteorite Ministry, @Ministry of Truth [Various]
 
-[Conflict]
+[Conflict] ; all conflict except 'Baar Dau - Ministry of Truth.esp' and 'Meteorite Ministry Palace.esp' (MassiveJuice)
 	These plugins all overhaul, move, or otherwise alter Baar Dau, use only one of them.
 Baar Dau.esp
 Baar Dau - Ministry of Truth.esp
-Meteorite Ministry Palace*.esp
-Meteorite Ministry Temple*.esp
 Higher Ministry of Truth.esp
+Meteorite Ministry Temple*.esp
+Meteorite Ministry Palace - Higher.esp
 
-[Note] ; ( Ref: https://www.nexusmods.com/morrowind/mods/51813 )
-	Make sure to use the patch from Vegetto's Important Patches
+;; Meteorite Ministry
+[Conflict] ; 'Meteorite Ministry Palace.esp' conflicts with other Baar Dau mods except 'Baar Dau - Ministry of Truth.esp' if using patch from Vegetto ( Ref: https://www.nexusmods.com/morrowind/mods/51813 ) (MassiveJuice)
+	These plugins all overhaul, move, or otherwise alter Baar Dau, use only one of them.
+Meteorite Ministry Palace.esp
+[ANY	Baar Dau.esp
+	Higher Ministry of Truth.esp
+	Meteorite Ministry Temple*.esp
+	Meteorite Ministry Palace - Higher.esp]
+
+[Note] ; ( Ref: https://www.nexusmods.com/morrowind/mods/51813 ) (Dary)
+	! Make sure to use the 'Meteorite Ministry - Baar Dau Ministry patch' patch from 'Vegetto's Important Patches'
 	[Patch Download]( https://www.nexusmods.com/morrowind/mods/51813 )
 [ALL	Meteorite Ministry Palace.esp
 	Baar Dau - Ministry of Truth.esp]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -4130,6 +4130,13 @@ abotGuars.esp
 abotGuars-OpenMW patch.ESP
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; @Guiding Guild [Kalinter]
+
+[Order] ; ( Ref: Guiding Guild description ) (Dary)
+Beautiful Cities of Morrowind.esp
+The Guiding Guild.esp
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Guild of Vampire Hunters [AliceL93]
 
 [Conflict]

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -7241,6 +7241,10 @@ The Sable Dragon*.esp
 Shipyards of Vvardenfell.esp
 Beautiful Cities of Morrowind.esp
 
+[Order] ; See mod description ( Ref: https://www.nexusmods.com/morrowind/mods/51928) (Dary)
+Marbled Zafirbel Bay.esp
+Shipyards of Vvardenfell.esp
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Silgrad Tower [Various]
 


### PR DESCRIPTION
Added and changed rules for:

- The Guiding Guild and BCOM
- DUFO (Arvesa v1.0) x BCoM x RMR x Memento Mori (compatibility patch)
- Meteorite Ministry patch for Baar Dau - Ministry of Truth (Vegetto's patches)
- Kogoruhn - Extinct City of Ash and Sulfur
- Shipyards of Vvardenfell and Marbled Zarfirbel Bay