### PR TITLE
add rule for Quick Character Creation

### DIFF
--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -30245,7 +30245,7 @@ DremoraLords.esp
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Quick Character Creation
 
-;; Quest Voice Greeting overwrites chargen captain's script, effectively breaking the chargen process
+;; Quest Voice Greetings overwrites chargen captain's script, effectively breaking the chargen process
 [Order]
 Quest Voice Greetings.ESP
 Quick Character Creation.esp

--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -30243,6 +30243,14 @@ Quorn Resource Integration.ESP
 DremoraLords.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; @Quick Character Creation
+
+;; Quest Voice Greeting overwrites chargen captain's script, effectively breaking the chargen process
+[Order]
+Quest Voice Greetings.ESP
+Quick Character Creation.esp
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Race/Birthsign Remix [paulkdad]
 
 ;;Load the specific race-affecting mod after WGI


### PR DESCRIPTION
Quest Voice Greetings overwrites chargen captain's script from Quick Character Creation, effectively breaking the chargen process (it makes it impossible to pick up documents from the census clerk). Only Jiub's script works correctly. 

If Quick Character Creation is loaded after Quest Voice Greetings, no issues arise.