### PR TITLE
Mages Guild Stronghold load order with BCOM and OMW

### DIFF
--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -41686,6 +41686,13 @@ X-jiit.esp
 X-jiitCompanionsTB.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Mages Guild Stronghold Nchagalelft load order for OpenMW patches from modding-openmw.com and BCOM
+[Order]
+MGO Building Up Nchagalelft.esp
+BCOM_MGOBuildingUpNchagalelft_Patch.esp
+MGOBuildingUpNchagalelft_OpenMWPatch.esp
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Zanpakuto Bleach mod  [Meusnoorn under my normal pseudonym Blodskaal]
 
 [Requires]


### PR DESCRIPTION
Mages Guild Stronghold (MGO Building Up Nchagalelft.esp) must be loaded before MGOBuildingUpNchagalelft_OpenMWPatch.esp (the esp from Modding-OpenMW Patches) and also BCOM_MGOBuildingUpNchagalelft_Patch.esp (which is the BCOM patch for this mod) otherwise the teleporters of the Mages Stronghold will teleport you out of bounds in Ald'Ruhn and Vivec mages guild.