### PR TITLE
Update mlox_base.txt

### DIFF
--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -41715,6 +41715,10 @@ Unholy Trinity Complete.esp
 OAAB_Grazelands.esp
 The Northern Strongholds.esp
 
+[Order]
+OAAB_Grazelands.esp
+TNSH Indoyanyon.esp
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Zanpakuto Bleach mod  [Meusnoorn under my normal pseudonym Blodskaal]
 

--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -41711,6 +41711,9 @@ Unholy Trinity Complete.esp
 [ANY	Unholy Trinity Dagoth Ur.esp
 		Unholy Trinity Odrosal.esp
 		Unholy Trinity Vemynal.esp]
+[Order]
+OAAB_Grazelands.esp
+The Northern Strongholds.esp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Zanpakuto Bleach mod  [Meusnoorn under my normal pseudonym Blodskaal]


### PR DESCRIPTION
Northern Strongholds must be loaded after OOAB Grazelands or else Indoranyon's doors will lead out of bounds.