### PR TITLE
A few syntax fixes and more precise patterns in VER predicates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Exclude mlox_base.txt from LF normalization as it was checked in with CRLF
+# line endings.
+mlox_base.txt -text

--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -31374,7 +31374,7 @@ RoHT Taddeus Balancing.esp
 	!! The LGNPC quests require that the player talks to Duke Dren, which will become impossible during the questline of "Rise of House Telvanni".
 	!! Patches for "Less Generic NPCs (LGNPC) Pax Redoran" will be made with the next version.
 	!! ( Ref: "Rise of House Telvanni v1.5 Readme.txt" )
-[ALL [ANY [VER < 1.21 LGNPC_PaxRedoran*.esp]
+[ALL [ANY [VER < 1.21 LGNPC_PaxRedoran_v<VER>*.esp]
 		  [VER < 1.20 LGNPC_TelUvirith_v<VER>.esp]]
 	 Rise of House Telvanni.esm]
 

--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -19138,7 +19138,7 @@ Antares' Tribunal Main QUest.esp
 [ALL ANPC.esp
 	 [ANY LGNPC_NoLore.esp
 		  LGNPC_SeydaNeen.esp
-		  LGNPC_GnaarMok_v<VER.esp
+		  LGNPC_GnaarMok_v<VER>.esp
 		  LGNPC_AldVelothi_v?_??.esp
 		  LGNPC_AldVelothi_rus_v?_??.esp
 		  LGNPC_MaarGan.esp
@@ -34097,7 +34097,7 @@ LGNPC Gowns.esp
 	 Less Lore.esp
 	 LGNPC_NoLore.esp
 	 LGNPC_SeydaNeen.esp
-	 LGNPC_GnaarMok_v<VER.esp
+	 LGNPC_GnaarMok_v<VER>.esp
 	 LGNPC_AldVelothi_v?_??.esp
 	 LGNPC_AldVelothi_rus_v?_??.esp
 	 LGNPC_MaarGan.esp

--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -7512,9 +7512,6 @@ AOF Potions Recolored T+B.esp
 [DESC /Tooplex/ BTB - Alchemy.esp]
 AOF Potions Recolored T+B.esp
 
-[Note] ; ( Ref: "BTBGI - MGSO Compatability V1.5-43522-1-5.rar\Readme.txt" )
-[DESC /Tooplex/ BTB - Alchemy.esp]
-
 ;;Dragon32: If someone's using another version of AOF's mod (and hopefully a TESTool Merged Objects plugin)
 [Order]
 AOF Potions Recolored.esp

--- a/mlox_base_legacy.txt
+++ b/mlox_base_legacy.txt
@@ -7826,7 +7826,7 @@ Better_Sounds.esp
 [ANY Tribunal.esm
      Bloodmoon.esm]
 
-;;ReadMe.htm - 
+;;ReadMe.htm -
 ;;Translator5: Version 1.1.0.1 is named without "_" included fixes & translation by FullRest-Team
 [Requires]
  This plugin uses Startup scripts
@@ -7846,7 +7846,7 @@ Better_Sounds.esp
      OfficialMods_v5.esp
      Official_2002_Mods.esp
      super_adventurers302.esp]
-     
+
 [Conflict]
  "If you have "Bitter Coast Sounds Plugin" (bcsounds.esp), don't use it"
  (Ref: "BetterSounds-9967.zip\ReadMe_ENG.txt")
@@ -29732,7 +29732,7 @@ MTT IV Master.esp
 [Note]
  !! Magical Trinkets of Tamriel IV (both Chris Woods' original, "MTT IV Master.esp", and the modified version by habile, "MTT IV Updated v0.79.esp") contains deprecated use of the function AddToLev*. For an explanation of why the functions AddToLev*/RemoveFromLev* are deprecated, please see: http://www.uesp.net/wiki/Tes3Mod:Leveled_Lists
  !! It is suggested that you get a replacement patch, such as Magical Trinkets of Tamriel IV beta - Dragon32 patch, from http://mw.modhistory.com/download-50-6822
-[ANY [ALL [MTT IV Master.esp
+[ANY [ALL MTT IV Master.esp
           [SIZE !1629334 MTT IV Master.esp]] ;;Dragon32's edited version
      MTT IV Updated v0.79.esp]
 
@@ -59467,4 +59467,3 @@ The Zone (Tribunal).esp
  !! This plugin contains evil GMSTs, and a few dirty references. It is recommended that you clean it with TESTool.
  !! (What the hell is a GMST? http://www.mwmythicmods.com/argent/tech/gmst.html )
 [SIZE 3900 Zyndaar's Bows.esp]
-

--- a/mlox_base_legacy.txt
+++ b/mlox_base_legacy.txt
@@ -51709,7 +51709,7 @@ Serpentax's Predator Tweaks.esp
 
 [Note]
  There is a newer version of "Twin Lamps and Slave Hunters" available, you should upgrade.
-[VER<1.5 Nevena's Twin Lamps & Slave Hunters *.esp]
+[VER<1.5 Nevena's Twin Lamps & Slave Hunters <VER>.esp]
 
 [Note]
  This plugin contains dirty references. It is recommended that you clean it with TESTool.


### PR DESCRIPTION
I came across these while testing my mlox-to-LOOT conversion script. The empty NOTE rule, the mismatched square brackets and the missing `>` characters all look like straightforward mistakes.

The VER predicate changes aren't fixes, but they shouldn't affect mlox's behaviour, and if accepted then I won't need to hardcode special handling for those two cases. From the commit message:

> Although they doesn't cause any problems for mlox, LOOT's almost-equivalent functionality requires <VER> to be present exactly once so it knows where in the filename to expect a version, because IMO it's better to be more precise if you can be.
>
> I've got lists of plugin filenames for all the mods that are available from Nexus Mods or are indexed at <https://modlist.altervista.org/mmh/index.php>, plus all the Morrowind Rebirth downloads on ModDB, and matching against those filenames gives the following results.
> 
> LGNPC_PaxRedoran*.esp matches:
> 
> LGNPC_PaxRedoran - Dialogue Script Fix.esp
> LGNPC_PaxRedoran.esp
> LGNPC_PaxRedoran_v1_20.esp
> LGNPC_PaxRedoran_v1_20_GOTYST.esp
> LGNPC_PaxRedoran_v1_20_PL.esp
> 
> Nevena's Twin Lamps & Slave Hunters *.esp matches:
> 
> Nevena's Twin Lamps & Slave Hunters 1.0.esp
> Nevena's Twin Lamps & Slave Hunters 1.2.esp
> Nevena's Twin Lamps & Slave Hunters 1.5.esp
> 
> So while this theoretically changes the behaviour of the rules, it looks like this won't change them in practice.

The added `.gitattributes` is because my local copy of git (on Windows) kept trying to normalise the line endings of `mlox_base.txt` to LF, creating a huge diff, and the `.gitattributes` config stopped that.