### PR TITLE
Add "Spell Effects Descriptions Corrected" to [NearStart]

### DIFF
--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -89,6 +89,7 @@ Half11 misc mods + anticheese.ESP
 Morrowind Anti-Cheese.ESP
 Ownership Overhaul.esp
 Ownership Overhaul.esm
+spell effect descriptions corrected.ESP ; ( Ref: Spell Effect Descriptions Corrected.txt )
 
 [Order]
 Morrowind.esm


### PR DESCRIPTION
The readme indicates that this should be loaded early so anything that actually changes spell effects (and descriptions) can overwrite it.