### PR TITLE
Add [Patch] and [Order] rules for patches included in ToTSP

### DIFF
--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -33861,6 +33861,18 @@ TOTSP_Patch_for_Purists_*.esp
 [ALL Solstheim Tomb of The Snow Prince.esm
      Patch for Purists.esm]
 
+;; Solstheim Tomb of The Snow Prince - Bloodmoon Rebalance compatibility patch
+;; From alvazir's Various Patches
+[Patch]
+ Corrects The Swimmer's AI Package to fit TotSP geography while keeping Rebalanced's stat changes. ( Ref: examination in CS )
+Solstheim Tomb of The Snow Prince - Bloodmoon Rebalance.esp
+[ALL Solstheim Tomb of The Snow Prince.esm
+     Bloodmoon Rebalance.ESP]
+
+[Order]
+Bloodmoon Rebalance.ESP
+Solstheim Tomb of The Snow Prince - Bloodmoon Rebalance.esp
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Solstheim Tomb of the Snow Prince - White Wolf of Lokken Compatibility [straub666]
 

--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -33841,6 +33841,27 @@ Clean Solstheim_Castle_v1.1.esp
 	 Solstheim TotSP [Rebirth].esp]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; @Solstheim - Tomb of the Snow Prince 2.2+ [wollibeebee]
+
+;; Forceful Travel NPC Override
+[Patch]
+ If you use Bloodmoon Rebalance with Solstheim Tomb of the Snow Prince, you should also use TotSP's TOTSP_Forceful_Travel_NPC_Override.esp. 
+ ( Ref: "This is necessary if you use Bloodmoon Rebalance or another mod overriding these NPC's travel markers." https://www.nexusmods.com/morrowind/mods/4681 )
+TOTSP_Forceful_Travel_NPC_Override.ESP
+[ALL Solstheim Tomb of The Snow Prince.esm
+     Bloodmoon Rebalance.ESP]
+
+[Order]
+Bloodmoon Rebalance.ESP
+TOTSP_Forceful_Travel_NPC_Override.ESP
+
+;; Patch for Purists patch
+[Patch]
+TOTSP_Patch_for_Purists_*.esp
+[ALL Solstheim Tomb of The Snow Prince.esm
+     Patch for Purists.esm]
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; @Solstheim Tomb of the Snow Prince - White Wolf of Lokken Compatibility [straub666]
 
 ;;Dragon32: There's an altered "BT_Whitewolf_2_0.esm" to use (only removes one Cell) but it's indistinguishable from Emma's original ESM except by filesize.


### PR DESCRIPTION
[Order] rules are not necessary for the PfP patch, since it is patching two .esms which will naturally load earlier than it does. Likewise, only one [Order] rule is necessary for the Forceful Travel NPC Override, since one of the things it patches is an .esm.