### PR TITLE
Move rule regarding Solstheim Castle to Solstheim Castle section

### DIFF
--- a/mlox_base.txt
+++ b/mlox_base.txt
@@ -33727,6 +33727,10 @@ Clean SCastle_LoKKen_Patch.esp
 	 [ANY BT_Whitewolf_2_0.esp
 		  BT_Whitewolf_2_0.esm]]
 
+[Order]
+BT_Whitewolf_2_0.esp
+Clean Solstheim_Castle_v1.1.esp
+
 [Order] ; Dragon32: Checked with TESPCD. LAND and NPC_ entries conflict.
 Clean Solstheim_Castle_v1.1.esp
 Clean SCastle_LoKKen_Patch.esp

--- a/mlox_user.txt
+++ b/mlox_user.txt
@@ -9356,11 +9356,6 @@ OAAB_Data.esm
 BT_Whitewolf_2_0_HOTV.esm
 
 [Order]
-BT_Whitewolf*.esm
-BT_Whitewolf*.esp
-Solstheim_Castle*.esp
-
-[Order]
 Solstheim Tomb of The Snow Prince.esm
 BT_Whitewolf*.esm
 


### PR DESCRIPTION
This rule should live with the existing rules about the patch for Korana's Solstheim Castle and Emma's Lokken.

The rule as it existed implied relationships between *any* Lokken and *any* Solstheim Castle that simply don't make sense for the various moved versions of each. I've changed it to specify Korana and Emma's final versions. 

In addition, there is no reason to specify an [Order] rule between an .esm and an .esp, so I've removed that.